### PR TITLE
Basic認証の追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,12 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
+  protect_from_forgery with: :exception
+
+  private
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,10 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth
+  before_action :basic_auth, if: :production?
   protect_from_forgery with: :exception
+
+  def production?
+    Rails.env.production?
+  end
 
   private
 

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,4 +1,6 @@
 server '54.65.138.229', user: 'ec2-user', roles: %w{app db web}
+set :rails_env, "production"
+set :unicorn_rack_env, "production"
 
 # server-based syntax
 # ======================


### PR DESCRIPTION
# what
Basic認証機能の追加。
本番環境でのみ認証を実行。

# why
簡易的にセキュリティを強化する。
今回の開発環境の場合は、開発チームメンバーのみ触るので、
本番環境でのみ、Basic認証を行うようにしている。