### PR TITLE
不要なファイルが生成されないように設定を変更

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,12 @@ module FreemarketSample65d
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-
+    config.generators do |g|
+      g.stylesheets false
+      g.javascripts false
+      g.helper false
+      g.test_framework false
+    end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
# what
rails g controllerのコマンドで
自動生成されるファイルを、コントローラーファイルのみに変更。

# why
不要なファイルが増えるのを防ぐため。