### PR TITLE
Categoryテーブルの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ## usersテーブル
-
 |Column|Type|Options|
 |------|----|-------|
 |nickname|string|null: false|
@@ -15,7 +14,6 @@
 - has_many :items
 - has_many :likes
 - has_many :comments
-- has_one : payment
 - has_one : address
 
 ## itemsテーブル
@@ -45,11 +43,9 @@
 |Column|Type|Options|
 |------|----|-------|
 |name|string|null: false|
-|brand_id|references|foreign_key: true|
 
 ### Association
 - has_many :items
-- belongs_to :brand
 
 ## brandsテーブル
 |Column|Type|Options|
@@ -79,18 +75,6 @@
 
 ### Association
 - belongs_to: item
-
-## paymentsテーブル
-|column|Type|Options|
-|-------|---------|-----------|
-|user_id|reference|foreign_key: true|
-|card_number|string|null: false unique: true|
-|year|integer|null: false|
-|month|integer|null: false|
-|security_number|integer|null: false|
-
-### Association
-- belongs_to :user
 
 ## addressテーブル
 |column|Type|Option|

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,3 @@
 class Category < ApplicationRecord
   has_many   :items
-  belongs_to :brand
 end

--- a/db/migrate/20200103075204_removebrand_id_from_categories.rb
+++ b/db/migrate/20200103075204_removebrand_id_from_categories.rb
@@ -1,0 +1,5 @@
+class RemovebrandIdFromCategories < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :categories, :brand_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_25_043048) do
+ActiveRecord::Schema.define(version: 2020_01_03_075204) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "build_name"
@@ -35,8 +35,6 @@ ActiveRecord::Schema.define(version: 2019_12_25_043048) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "brand_id"
-    t.index ["brand_id"], name: "index_categories_on_brand_id"
   end
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -104,7 +102,6 @@ ActiveRecord::Schema.define(version: 2019_12_25_043048) do
   end
 
   add_foreign_key "addresses", "users"
-  add_foreign_key "categories", "brands"
   add_foreign_key "comments", "items"
   add_foreign_key "comments", "users"
   add_foreign_key "images", "items"


### PR DESCRIPTION
# what
categoryテーブルから
brand_idカラムを削除。

# why
categoryテーブルに、brand_idが紐づいていると
item登録時に処理が面倒になる為。
また、現状必要な箇所がない為。